### PR TITLE
Require 'active_support' first

### DIFF
--- a/lib/resource_kit.rb
+++ b/lib/resource_kit.rb
@@ -1,4 +1,5 @@
 require "resource_kit/version"
+require 'active_support'
 require 'active_support/core_ext'
 require 'faraday'
 


### PR DESCRIPTION
I was hitting an [error](https://travis-ci.org/RoboticCheese/clamav-chef/builds/36737386#L184) in an application that uses this gem by way of droplet_kit:

```
NameError: uninitialized constant ActiveSupport::Autoload
```

and was led to https://github.com/rails/rails/issues/14664. Adding the suggested extra `require` seems to fix the issue.
