### PR TITLE
Allow specifying a default handler for all codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ class DropletResource < ResourceKit::Resource
   resources do
     default_handler(422) { |response| ErrorMapping.extract_single(response.body, :read) }
     default_handler(:ok, :created) { |response| DropletMapping.extract_single(response.body, :read) }
+    default_handler { |response| raise "Unexpected response status #{response.status}... #{response.body}" }
 
     # Defining actions will create instance methods on the resource class to call them.
     action :find do

--- a/lib/resource_kit/action.rb
+++ b/lib/resource_kit/action.rb
@@ -31,11 +31,13 @@ module ResourceKit
     end
 
     def handler(*response_codes, &block)
-      response_codes.each do |code|
-        unless code.is_a?(Fixnum)
-          code = StatusCodeMapper.code_for(code)
+      if response_codes.empty?
+        handlers[:any] = block
+      else
+        response_codes.each do |code|
+          code = StatusCodeMapper.code_for(code) unless code.is_a?(Fixnum)
+          handlers[code] = block
         end
-        handlers[code] = block
       end
     end
 

--- a/lib/resource_kit/action_invoker.rb
+++ b/lib/resource_kit/action_invoker.rb
@@ -15,7 +15,7 @@ module ResourceKit
     end
 
     def handle_response
-      if handler = action.handlers[response.status]
+      if handler = action.handlers[response.status] || action.handlers[:any]
         resource.instance_exec(response, &handler)
       else
         response.body

--- a/lib/resource_kit/resource_collection.rb
+++ b/lib/resource_kit/resource_collection.rb
@@ -22,11 +22,13 @@ module ResourceKit
     end
 
     def default_handler(*response_codes, &block)
-      response_codes.each do |code|
-        unless code.is_a?(Fixnum)
-          code = StatusCodeMapper.code_for(code)
+      if response_codes.empty?
+        default_handlers[:any] = block
+      else
+        response_codes.each do |code|
+          code = StatusCodeMapper.code_for(code) unless code.is_a?(Fixnum)
+          default_handlers[code] = block
         end
-        default_handlers[code] = block
       end
     end
 

--- a/spec/lib/resource_kit/action_invoker_spec.rb
+++ b/spec/lib/resource_kit/action_invoker_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe ResourceKit::ActionInvoker do
         result = ResourceKit::ActionInvoker.call(action, resource)
         expect(result).to eq('404ed')
       end
+
+      it 'uses a default handler if provided' do
+        action.verb :get
+        action.path '/users'
+        action.handler { |response| 'Something unexpected happened.' }
+
+        result = ResourceKit::ActionInvoker.call(action, resource)
+        expect(result).to eq('Something unexpected happened.')
+      end
     end
 
     context 'for requests with bodies' do

--- a/spec/lib/resource_kit/resource_collection_spec.rb
+++ b/spec/lib/resource_kit/resource_collection_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe ResourceKit::ResourceCollection do
       expect(collection.default_handlers[200]).to eq(handler_block)
       expect(collection.default_handlers[204]).to eq(handler_block)
     end
+
+    it 'provides a top-level default handler if no status code is provided' do
+      handler_block = Proc.new { true }
+      collection.default_handler(&handler_block)
+
+      expect(collection.default_handlers[:any]).to eq(handler_block)
+    end
   end
 
   describe '#action' do
@@ -32,12 +39,17 @@ RSpec.describe ResourceKit::ResourceCollection do
 
     context 'when default handlers have been specified on the collection' do
       let(:handler) { Proc.new { |response| 'sure' } }
+      let(:default_handler) { Proc.new { 'Something unexpected happened!' } }
 
-      before { collection.default_handler(:ok, &handler) }
+      before do
+        collection.default_handler(:ok, &handler)
+        collection.default_handler(&default_handler)
+      end
 
       it 'prepends the default handlers to the test' do
         action = collection.action(:all)
         expect(action.handlers[200]).to eq(handler)
+        expect(action.handlers[:any]).to eq(default_handler)
       end
     end
   end

--- a/spec/lib/resource_kit/resource_spec.rb
+++ b/spec/lib/resource_kit/resource_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ResourceKit::Resource do
 
       it "defines the action method" do
         expect(droplet_resource).to respond_to(:find)
+        expect(droplet_resource).to respond_to(:all)
       end
     end
   end


### PR DESCRIPTION
If `default_handler` or `handler` is called with only a block and
without a status code passed, it will add a handler that will be called
for all status codes that don't have their own handler specified:

``` ruby
class DropletKit < ResourceKit::Resource
  default_handler { 'Something unexpected happened!' }

  action :all, 'GET /droplets' do
    handler(:ok) { |response| Droplet.from_json(response) }
  end
end
```

If anything but a 200 is returned from `GET /droplets`, the specified
string will be returned.

Signed-off-by: David Celis me@davidcel.is
