### PR TITLE
Remove dependency on ActiveSupport (fixes #8)

### DIFF
--- a/lib/resource_kit.rb
+++ b/lib/resource_kit.rb
@@ -1,5 +1,4 @@
-require "resource_kit/version"
-require 'active_support/core_ext'
+require 'resource_kit/version'
 require 'faraday'
 
 module ResourceKit

--- a/lib/resource_kit/action_invoker.rb
+++ b/lib/resource_kit/action_invoker.rb
@@ -29,10 +29,10 @@ module ResourceKit
     def response
       return @response if @response
 
-      raise ArgumentError, "Verb '#{action.verb}' is not allowed" unless action.verb.in?(ALLOWED_VERBS)
+      raise ArgumentError, "Verb '#{action.verb}' is not allowed" unless ALLOWED_VERBS.include?(action.verb)
 
       @response = connection.send(action.verb, resolver.resolve(options)) do |request|
-        request.body = construct_body if action.body and action.verb.in?([:post, :put, :patch])
+        request.body = construct_body if action.body and [:post, :put, :patch].include?(action.verb)
         append_hooks(:before, request)
       end
     end

--- a/lib/resource_kit/endpoint_resolver.rb
+++ b/lib/resource_kit/endpoint_resolver.rb
@@ -27,16 +27,18 @@ module ResourceKit
     end
 
     def normalized_path_components(*components)
-      components.reject(&:blank?).map do |piece|
+      components.reject(&:empty?).map do |piece|
         # Remove leading and trailing forward slashes
         piece.gsub(/(^\/)|(\/$)/, '')
       end.join('/').insert(0, '/')
     end
 
     def append_query_values(uri, values)
-      query_param_keys.each_with_object({}) do |key, query_values|
+      params = query_param_keys.each_with_object({}) do |key, query_values|
         query_values[key] = values[key] if values.has_key?(key)
-      end.to_query
+      end
+
+      URI.encode_www_form(params)
     end
   end
 end

--- a/lib/resource_kit/inheritable_attribute.rb
+++ b/lib/resource_kit/inheritable_attribute.rb
@@ -1,0 +1,20 @@
+module ResourceKit
+  module InheritableAttribute
+    def inheritable_attr(name)
+      instance_eval <<-RUBY
+        def #{name}=(v)
+          @#{name} = v
+        end
+
+        def #{name}
+          @#{name} ||= InheritableAttribute.inherit(self, :#{name})
+        end
+      RUBY
+    end
+
+    def self.inherit(klass, name)
+      return unless klass.superclass.respond_to?(name) and value = klass.superclass.send(name)
+      value.clone
+    end
+  end
+end

--- a/lib/resource_kit/resource.rb
+++ b/lib/resource_kit/resource.rb
@@ -1,6 +1,9 @@
+require 'resource_kit/inheritable_attribute'
+
 module ResourceKit
   class Resource
-    class_attribute :_resources
+    extend InheritableAttribute
+    inheritable_attr :_resources
 
     attr_reader :connection, :scope
 
@@ -26,6 +29,12 @@ module ResourceKit
 
     def action_and_connection(action_name)
       ActionConnection.new(action(action_name), connection)
+    end
+
+    private
+
+    def _resources
+      self.class._resources
     end
   end
 end

--- a/lib/resource_kit/testing/action_handler_matchers.rb
+++ b/lib/resource_kit/testing/action_handler_matchers.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module ResourceKit
   module Testing
     class ActionHandlerMatchers

--- a/resource_kit.gemspec
+++ b/resource_kit.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday'
-  spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'addressable', '~> 2.3.6'
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/spec/lib/resource_kit/inheritable_attribute_spec.rb
+++ b/spec/lib/resource_kit/inheritable_attribute_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe ResourceKit::InheritableAttribute do
+  subject do
+    Class.new(Object) do
+      extend ResourceKit::InheritableAttribute
+
+      inheritable_attr :_resources
+    end
+  end
+
+  it 'provides a reader with an empty inherited attribute' do
+    expect(subject._resources).to be_nil
+  end
+
+  it 'provides a reader with empty inherited attributes in a derived class' do
+    expect(Class.new(subject)._resources).to be_nil
+
+    # subject._resouces = true
+    # Class.new(subject)._resources # TODO: crashes.
+  end
+
+  it 'provides an attribute copy in subclasses' do
+    subject._resources = []
+    expect(subject._resources.object_id).not_to eq Class.new(subject)._resources.object_id
+  end
+
+  it 'provides a writer' do
+    subject._resources = [:resource]
+    expect(subject._resources).to eq [:resource]
+  end
+
+  it 'inherits attributes' do
+    subject._resources = [:resource]
+
+    subclass_a = Class.new(subject)
+    subclass_a._resources << :another_resource
+
+    subclass_b = Class.new(subject)
+    subclass_b._resources << :different_resource
+
+    expect(subject._resources).to eq [:resource]
+    expect(subclass_a._resources).to eq [:resource, :another_resource]
+    expect(subclass_b._resources).to eq [:resource, :different_resource]
+  end
+
+  it 'does not inherit attributes if we set explicitely' do
+    subject._resources = [:resource]
+    subclass = Class.new(subject)
+
+    subclass._resources = [:another_resource]
+    expect(subclass._resources).to eq [:another_resource]
+  end
+end


### PR DESCRIPTION
We only use ActiveSupport for a few core extensions that are easily
swapped out for their slightly-less-readable alternatives. There is also
a single instance of `class_attribute`, but that is easily implemented
as a mixin (included, tested)

Signed-off-by: David Celis me@davidcel.is
