### PR TITLE
Fix paths that already have query params on them.

### DIFF
--- a/lib/resource_kit/endpoint_resolver.rb
+++ b/lib/resource_kit/endpoint_resolver.rb
@@ -10,8 +10,9 @@ module ResourceKit
     end
 
     def resolve(values = {})
-      uri = Addressable::URI.new
-      new_path = generated_path(values)
+      uri = Addressable::URI.parse(path)
+      new_path = generated_path(uri.path, values)
+
       uri.path = normalized_path_components(new_path)
       uri.query = append_query_values(uri, values) unless query_param_keys.empty?
 
@@ -20,7 +21,7 @@ module ResourceKit
 
     private
 
-    def generated_path(values)
+    def generated_path(path, values)
       values.inject(path) do |np, (key, value)|
         np.gsub(":#{key}", value.to_s)
       end
@@ -34,7 +35,8 @@ module ResourceKit
     end
 
     def append_query_values(uri, values)
-      params = query_param_keys.each_with_object({}) do |key, query_values|
+      pre_vals = uri.query_values || {}
+      params = query_param_keys.each_with_object(pre_vals) do |key, query_values|
         query_values[key] = values[key] if values.has_key?(key)
       end
 

--- a/lib/resource_kit/endpoint_resolver.rb
+++ b/lib/resource_kit/endpoint_resolver.rb
@@ -21,8 +21,8 @@ module ResourceKit
 
     private
 
-    def generated_path(path, values)
-      values.inject(path) do |np, (key, value)|
+    def generated_path(supplied_path, values)
+      values.inject(supplied_path) do |np, (key, value)|
         np.gsub(":#{key}", value.to_s)
       end
     end

--- a/spec/lib/resource_kit/endpoint_resolver_spec.rb
+++ b/spec/lib/resource_kit/endpoint_resolver_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe ResourceKit::EndpointResolver do
   end
 
   describe '#resolve' do
-    let(:options) { { path: '/users' } }
+    let(:path) { '/users' }
+    let(:query_param_keys) { [] }
+    let(:options) { { path: path, query_param_keys: query_param_keys } }
+
     subject(:resolver) { ResourceKit::EndpointResolver.new(options) }
 
     context 'simple resolve' do
@@ -23,7 +26,7 @@ RSpec.describe ResourceKit::EndpointResolver do
     end
 
     context 'substituted paths' do
-      let(:options) { super().merge(path: '/users/:id') }
+      let(:path) { '/users/:id' }
 
       it 'creates a populated URL from passed values' do
         endpoint = resolver.resolve(id: 1066)
@@ -32,7 +35,7 @@ RSpec.describe ResourceKit::EndpointResolver do
     end
 
     context 'with query parameters' do
-      let(:options) { super().merge(path: '/users', query_param_keys: [:per_page, :page]) }
+      let(:query_param_keys) { [:per_page, :page] }
 
       it 'generates a URL with query parameters set correctly' do
         endpoint = resolver.resolve(per_page: 2, page: 3)
@@ -43,7 +46,8 @@ RSpec.describe ResourceKit::EndpointResolver do
     end
 
     context 'with query parameters already appended' do
-      let(:options) { super().merge(path: '/:something/users?foo=bar', query_param_keys: [:per_page, :page]) }
+      let(:path) { '/:something/users?foo=bar' }
+      let(:query_param_keys) { [:per_page, :page] }
 
       it 'appends the query params to the url that already has some' do
         endpoint = resolver.resolve(something: 'testing', per_page: 2, page: 3)

--- a/spec/lib/resource_kit/endpoint_resolver_spec.rb
+++ b/spec/lib/resource_kit/endpoint_resolver_spec.rb
@@ -41,5 +41,16 @@ RSpec.describe ResourceKit::EndpointResolver do
         expect(uri.query_values).to eq("per_page" => '2', "page" => '3')
       end
     end
+
+    context 'with query parameters already appended' do
+      let(:options) { super().merge(path: '/:something/users?foo=bar', query_param_keys: [:per_page, :page]) }
+
+      it 'appends the query params to the url that already has some' do
+        endpoint = resolver.resolve(something: 'testing', per_page: 2, page: 3)
+
+        uri = Addressable::URI.parse(endpoint)
+        expect(uri.query_values).to eq("foo" => 'bar', "per_page" => '2', "page" => '3')
+      end
+    end
   end
 end


### PR DESCRIPTION
If a path defined for an action has `/mypath?myparams=something` Then this would choke HARD core. This fixes it.