### PR TITLE
Pass the initial object back to the response handling blocks.

### DIFF
--- a/examples/digitalocean_droplets.rb
+++ b/examples/digitalocean_droplets.rb
@@ -39,6 +39,13 @@ class DropletResource < ResourceKit::Resource
       body { |object| DropletMapping.representation_for(:create, object) }
       handler(202) { |response| DropletMapping.extract_single(response.body, :read) }
     end
+
+    action :update do
+      verb :put
+      path '/v2/droplets/123'
+      body { |object| DropletMapping.representation_for(:create, object) }
+      handler(200) { |response, object| DropletMapping.extract_into_object(object, response.body, :read) }
+    end
   end
 end
 

--- a/lib/resource_kit/action_invoker.rb
+++ b/lib/resource_kit/action_invoker.rb
@@ -16,7 +16,7 @@ module ResourceKit
 
     def handle_response
       if handler = action.handlers[response.status] || action.handlers[:any]
-        resource.instance_exec(response, &handler)
+        resource.instance_exec(response, *args, &handler) # Since the handler is a block, it does not enforce parameter length checking
       else
         response.body
       end

--- a/spec/lib/resource_kit/action_invoker_spec.rb
+++ b/spec/lib/resource_kit/action_invoker_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe ResourceKit::ActionInvoker do
         expect(result).to eq('changed')
       end
 
+      it 'passes the initial object' do
+        action.verb :get
+        action.path '/users'
+        action.handler(200) { |response, hash| hash }
+
+        target_hash = Hash.new
+        result = ResourceKit::ActionInvoker.call(action, resource, target_hash)
+
+        expect(result).to be target_hash
+      end
+
       it 'uses the correct handler on status codes' do
         action.verb :get
         action.path '/users/bad_page'


### PR DESCRIPTION
Optionally pass the args passed to a resource's action to the handling block.

This is the long-lost partner to https://github.com/digitalocean/kartograph/issues/10, which will make possible the example shown in this PR (https://github.com/digitalocean/resource_kit/compare/feature/reuse-args?expand=1#diff-bf64f468fe3451985ec1e419b4fffe6fR43), and that will allow droplet_kit to replace https://github.com/digitalocean/droplet_kit/pull/49.

cc @nanzhong