### PR TITLE
ActionHandlerMatchers.failure_message more informative

### DIFF
--- a/lib/resource_kit/testing/action_handler_matchers.rb
+++ b/lib/resource_kit/testing/action_handler_matchers.rb
@@ -22,13 +22,13 @@ module ResourceKit
         @handled_block ||= block
         action = subject.resources.find_action(self.action)
         unless action
-          @failure_message = "expected :#{self.action} to be handled by #{subject.class.name}."
+          @failure_message = "expected :#{self.action} to be handled by #{subject.name}."
           return false
         end
 
         status_code = response_stub.status || 200
         unless action.handlers[status_code]
-          @failure_message = "expected the #{status_code} status code to be handled by #{subject.class.name}."
+          @failure_message = "expected the #{status_code} status code to be handled by #{subject.name}."
           return false
         end
 

--- a/spec/lib/resource_kit/testing/action_handler_matchers_spec.rb
+++ b/spec/lib/resource_kit/testing/action_handler_matchers_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ResourceKit::Testing::ActionHandlerMatchers do
 
   describe '#failure_message' do
     before(:each) do
-      allow(resource_class.class).to receive(:name).and_return("CustomClassName")
+      allow(resource_class).to receive(:name).and_return("CustomClassName")
     end
 
     context "when the matchers doesnt handle the same status code" do


### PR DESCRIPTION
Rather than saying "the class" specify the exact class name that is expected to return the action.  Could be useful when generating large amount of tests dynamically.
