### PR TITLE
Action#query_keys accepts an array

### DIFF
--- a/lib/resource_kit/action.rb
+++ b/lib/resource_kit/action.rb
@@ -23,7 +23,7 @@ module ResourceKit
 
     def query_keys(*keys)
       return @query_keys if keys.empty?
-      @query_keys += keys
+      @query_keys += keys.flatten
     end
 
     def handlers

--- a/spec/lib/resource_kit/action_spec.rb
+++ b/spec/lib/resource_kit/action_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe ResourceKit::Action do
       action.query_keys :per_page, :page
       expect(action.query_keys).to include(:per_page, :page)
     end
+
+    it "allows setting known query parameters as an array" do
+      action.query_keys [:per_page, :page]
+      expect(action.query_keys).to include(:per_page, :page)
+    end
   end
 
   describe '#before_request' do


### PR DESCRIPTION
This is so you can do something like

`action.query_keys %i[querykey1 querykey2 ... querykey200]`.  I don't see any downsides to supporting this :)