### PR TITLE
Prepare to tag v0.1.8

### DIFF
--- a/lib/resource_kit/version.rb
+++ b/lib/resource_kit/version.rb
@@ -1,3 +1,3 @@
 module ResourceKit
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
Prepares to release a tag for `v0.1.8` for the changes introduced in #38.