### PR TITLE
ci: bump ruby, gem versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ 2.5, 2.6, 2.7, '3.0' ]
-    runs-on: ubuntu-latest
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2 ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/resource_kit.gemspec
+++ b/resource_kit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = ''
   spec.homepage      = "https://github.com/digitaloceancloud/resource_kit"
   spec.license       = "MIT"
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'faraday'
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency "webmock", "~> 1.18.0"
   spec.add_development_dependency "kartograph", "~> 0.0.8"
-  spec.add_development_dependency "pry", "~> 0.10.1"
+  spec.add_development_dependency "pry", "~> 0.14.0"
 end

--- a/resource_kit.gemspec
+++ b/resource_kit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = ''
   spec.homepage      = "https://github.com/digitaloceancloud/resource_kit"
   spec.license       = "MIT"
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Bumps the minimum required Ruby version to be consistent with the tests, adds the latest Ruby versions, and bumps two gems to get rspec to actually run.